### PR TITLE
Fixing problems in the insert feed post process

### DIFF
--- a/includes/feeds.php
+++ b/includes/feeds.php
@@ -179,6 +179,11 @@ class PF_Feeds_Schema {
 		
 		#$wp_args = wp_parse_args( $r, $wp_args_d );
 		
+		if (empty($wp_args['post_title']) || !$wp_args['post_title']){
+			pf_log('Missing a title, assigning the URL');
+			$wp_args['post_title'] = $r['url'];
+		}
+		
 		pf_log('Will now ' . $insert_type . ' a post with the following args:');
 		pf_log($wp_args); #die();
 		
@@ -274,7 +279,8 @@ class PF_Feeds_Schema {
 			'module_added' 	=> 'rss-import',
 			'tags'    => array(),
 		) );
-		
+		pf_log('Received a create command with the following arguments:');
+		pf_log($r);
 		if ($r['type'] == 'rss'){
 		
 			if (is_wp_error($theFeed = fetch_feed($feedUrl))){


### PR DESCRIPTION
Problems being caused by the system somehow not assigning a title
regardless of rss-quick status. Need to check in on why that is
occurring. Still checking too many times during create process. Need to
make that more effective and efficient without all the checks and
queries.
