### PR TITLE
For feeds not in one folder, show them all in a row on the bottom.

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -101,8 +101,7 @@ visibility:hidden;
 }
 
 #feed-folders{
-	overflow:auto;
-	max-height: 1110px;
+
 }
 
 #feed-accordion .well, #nom-accordion .well  {

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -100,6 +100,11 @@ visibility:hidden;
 
 }
 
+#feed-folders{
+	overflow:auto;
+	max-height: 1110px;
+}
+
 #feed-accordion .well, #nom-accordion .well  {
 	padding: 0;
 	background-color: #FAFAFA;
@@ -674,6 +679,16 @@ h3 {
 		left: 200px;
 		
 	}
+
+	.right-bar-fix {
+		position: fixed;
+		top: 70px;
+		width: 25%;
+		z-index: 9991;
+		margin: 0;
+		right: 0px;
+	}
+
 /**
  * Specific override styles.
  *

--- a/assets/css/susy.css
+++ b/assets/css/susy.css
@@ -79,7 +79,10 @@
   #tools, #feed-folders {
     float: right;
     width: 25%;
-    padding: 40px;
+    padding: 30px;
+    padding-top:40px;
+    overflow:auto;
+    max-height: 1110px;
   }
   #tools h2, #feed-folders h2 {
     font-size: 1.125em;

--- a/assets/js/views.js
+++ b/assets/js/views.js
@@ -304,16 +304,20 @@ function attach_menu_on_scroll_past(){
 
 		if(y_scroll_pos > scroll_pos_test) {
 		   jQuery('.pf_container .display').addClass('nav-fix');
+		   jQuery('.pf_container #feed-folders').addClass('right-bar-fix');
+		   jQuery('.pf_container #tools').addClass('right-bar-fix');
+		   
 		}
 		else
 		{
 			jQuery('.pf_container .display').removeClass('nav-fix');
+			jQuery('.pf_container #feed-folders').removeClass('right-bar-fix');
+			jQuery('.pf_container #tools').addClass('right-bar-fix');
 		}
 	});
 }
 
-function detect_view_change(){
-
+function detect_view_change(){right-bar-fix
 	jQuery('.pf_container').on('click', 'button.display-state', function(evt){
 		var element = jQuery(this);
 		var go_layout = element.attr('id');

--- a/includes/feeds.php
+++ b/includes/feeds.php
@@ -257,6 +257,7 @@ class PF_Feeds_Schema {
 		   				array( 
 		 		            'post_type' => pressforward()->pf_feeds->post_type,
 		 		            'fields'	=>	'ids',
+		 		            'nopaging' => true,
 		 		            'tax_query' => array( 
 		 		                array( 
 		 		                    'taxonomy' => pressforward()->pf_feeds->tag_taxonomy, 
@@ -271,8 +272,30 @@ class PF_Feeds_Schema {
 
 	}
 
-	public function the_feed_folders($obj = false){
+	public function link_to_see_all_feeds_and_folders(){
+		?>
+		<li class="feed" id="the-whole-feed-list">
+		<?php
+
+			printf('<a href="%s" title="%s">%s</a>', $feed_obj->ID, $feed_obj->post_title, $feed_obj->post_title );
+
+		?>
+		</li>
+		<?php
+	}
+
+	public function the_feeds_without_folders(){
 		global $wp_version;
+		#var_dump((float)$wp_version);
+		if ( 4.0 < (float)$wp_version){
+			$the_other_feeds = $this->get_feeds_without_folders();
+			foreach ($the_other_feeds as $a_feed_id){
+				$this->the_feed($a_feed_id);
+			}
+		}
+	}
+
+	public function the_feed_folders($obj = false){
 		if(!$obj){
 			$obj = $this->get_feed_folders();
 		}
@@ -288,12 +311,8 @@ class PF_Feeds_Schema {
 					</li>
 					<?php
 				}
-				if ( 4 > (float)$wp_version){
-					$the_other_feeds = $this->get_feeds_without_folders();
-					foreach ($the_other_feeds as $a_feed_id){
-						$this->the_feed($a_feed_id);
-					}
-				}
+				
+				$this->the_feeds_without_folders();
 				?>
 		</ul>
 		<?php

--- a/includes/feeds.php
+++ b/includes/feeds.php
@@ -257,6 +257,8 @@ class PF_Feeds_Schema {
 		   				array( 
 		 		            'post_type' => pressforward()->pf_feeds->post_type,
 		 		            'fields'	=>	'ids',
+		 		            'orderby'	=> 'title',
+		 		            'order'		=> 'ASC',
 		 		            'nopaging' => true,
 		 		            'tax_query' => array( 
 		 		                array( 

--- a/includes/feeds.php
+++ b/includes/feeds.php
@@ -252,7 +252,27 @@ class PF_Feeds_Schema {
 
 	}
 
+	public function get_feeds_without_folders($ids = true){
+		   $q = new WP_Query( 
+		   				array( 
+		 		            'post_type' => pressforward()->pf_feeds->post_type,
+		 		            'fields'	=>	'ids',
+		 		            'tax_query' => array( 
+		 		                array( 
+		 		                    'taxonomy' => pressforward()->pf_feeds->tag_taxonomy, 
+		 		                    'operator' => 'NOT EXISTS', 
+		 		                ), 
+		 		            ), 
+ 		       			) 
+		   	);
+		   $ids = $q->posts;
+		   return $ids;
+
+
+	}
+
 	public function the_feed_folders($obj = false){
+		global $wp_version;
 		if(!$obj){
 			$obj = $this->get_feed_folders();
 		}
@@ -267,6 +287,12 @@ class PF_Feeds_Schema {
 					?>
 					</li>
 					<?php
+				}
+				if ( 4 > (float)$wp_version){
+					$the_other_feeds = $this->get_feeds_without_folders();
+					foreach ($the_other_feeds as $a_feed_id){
+						$this->the_feed($a_feed_id);
+					}
 				}
 				?>
 		</ul>

--- a/includes/internal-templates.php
+++ b/includes/internal-templates.php
@@ -67,4 +67,11 @@ class PF_Form_Of {
 		return $screen_array;
 	}
 
+	public function is_a_pf_page(){
+		$screen = $this->the_screen;
+		$is_pf = self::valid_pf_page_ids($screen['id']);
+		$this->is_pf = $is_pf;
+		return $is_pf;
+	}
+
 }

--- a/includes/internal-templates.php
+++ b/includes/internal-templates.php
@@ -31,6 +31,8 @@ class PF_Form_Of {
 		if (WP_DEBUG && $is_pf){
 			var_dump("PF screen trace: ID: $id; action: $action; base: $base; parent_base: $parent_base; parent_file: $parent_file; post_type: $post_type; taxonomy: $taxonomy;");
 		}
+		#echo $base;
+		return;
 	}
 
 	public function valid_pf_page_ids($page_id = false){

--- a/includes/internal-templates.php
+++ b/includes/internal-templates.php
@@ -14,25 +14,7 @@ class PF_Form_Of {
 
 	public function init() {
 		$this->parts = PF_ROOT . "/parts/";
-		$this->the_screen();
-	}
-
-	public function the_screen(){
-		#global $current_screen;
-		$screen = get_current_screen();
-		$id = $screen->id;
-		$action = $screen->action;
-		$base = $screen->base;
-		$parent_base = $screen->parent_base;
-		$parent_file = $screen->parent_file;
-		$post_type = $screen->post_type;
-		$taxonomy = $screen->taxonomy;
-		$is_pf = self::valid_pf_page_ids($id);
-		if (WP_DEBUG && $is_pf){
-			var_dump("PF screen trace: ID: $id; action: $action; base: $base; parent_base: $parent_base; parent_file: $parent_file; post_type: $post_type; taxonomy: $taxonomy;");
-		}
-		#echo $base;
-		return;
+		$this->the_screen = $this->the_screen();
 	}
 
 	public function valid_pf_page_ids($page_id = false){
@@ -52,6 +34,37 @@ class PF_Form_Of {
 		} else {
 			return $valid;
 		}
+	}
+
+	public function the_screen(){
+		#global $current_screen;
+		$screen = get_current_screen();
+		$id = $screen->id;
+		$action = $screen->action;
+		$base = $screen->base;
+		$parent_base = $screen->parent_base;
+		$parent_file = $screen->parent_file;
+		$post_type = $screen->post_type;
+		$taxonomy = $screen->taxonomy;
+		$is_pf = self::valid_pf_page_ids($id);
+		if (WP_DEBUG && $is_pf){
+			var_dump("PF screen trace: ID: $id; action: $action; base: $base; parent_base: $parent_base; parent_file: $parent_file; post_type: $post_type; taxonomy: $taxonomy;");
+		}
+		#echo $base;
+		$screen_array = array(
+
+				'screen' 		=> $screen,
+				'id'			=> $id,
+				'action'		=> $action,
+				'base'			=> $base,
+				'parent_base'	=> $parent_base,
+				'parent_file'	=> $parent_file,
+				'post_type'		=> $post_type,
+				'taxonomy'		=> $taxonomy
+
+			);
+		$screen_array = apply_filters('pf_screen', $screen_array);
+		return $screen_array;
 	}
 
 }

--- a/includes/internal-templates.php
+++ b/includes/internal-templates.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * Setting up the admin interface pieces, including menus and AJAX
+ *
+ * @since 3.5
+ */
+
+class PF_Form_Of {
+
+	public function __construct() {
+		add_action( 'current_screen', array( $this, 'init' ) );
+	}
+
+	public function init() {
+		$this->parts = PF_ROOT . "/parts/";
+		$this->the_screen();
+	}
+
+	public function the_screen(){
+		#global $current_screen;
+		$screen = get_current_screen();
+		$id = $screen->id;
+		$action = $screen->action;
+		$base = $screen->base;
+		$parent_base = $screen->parent_base;
+		$parent_file = $screen->parent_file;
+		$post_type = $screen->post_type;
+		$taxonomy = $screen->taxonomy;
+		$is_pf = self::valid_pf_page_ids($id);
+		if (WP_DEBUG && $is_pf){
+			var_dump("PF screen trace: ID: $id; action: $action; base: $base; parent_base: $parent_base; parent_file: $parent_file; post_type: $post_type; taxonomy: $taxonomy;");
+		}
+	}
+
+	public function valid_pf_page_ids($page_id = false){
+		$valid = array(
+				'toplevel_page_pf-menu',
+				'pressforward_page_pf-review',
+				'pressforward_page_pf-feeder',
+				'edit-pf_feed',
+				'pressforward_page_pf-options',
+				'pressforward_page_pf-tools',
+				'edit-pf_feed_category',
+				'pressforward_page_pf-debugger'
+			);
+		$valid = apply_filters('pf_page_ids', $valid);
+		if (false != $page_id){
+			return in_array($page_id, $valid);
+		} else {
+			return $valid;
+		}
+	}
+
+}

--- a/pressforward.php
+++ b/pressforward.php
@@ -84,6 +84,7 @@ class PressForward {
 		$this->set_up_relationships();
 		$this->set_up_feed_retrieve();
 		$this->set_up_nominations();
+		$this->set_up_form_of();
 		$this->set_up_admin();
 
 		add_action( 'plugins_loaded', array( $this, 'pressforward_init' ) );
@@ -133,9 +134,10 @@ class PressForward {
 		require_once( PF_ROOT . '/includes/slurp.php' );
 		require_once( PF_ROOT . '/includes/relationships.php' );
 		require_once( PF_ROOT . '/includes/nominations.php' );
+		require_once( PF_ROOT . '/includes/internal-templates.php' );
 		require_once( PF_ROOT . '/includes/admin.php' );
-    require_once( PF_ROOT . '/includes/template-tags.php' );
-    require_once( PF_ROOT . '/includes/alert-box/alert-box.php' );
+    	require_once( PF_ROOT . '/includes/template-tags.php' );
+    	require_once( PF_ROOT . '/includes/alert-box/alert-box.php' );
 		require_once( PF_ROOT . '/lib/urlresolver/URLResolver.php' );
 
 	}
@@ -236,6 +238,17 @@ class PressForward {
 	function set_up_nominations() {
 		if ( empty( $this->nominations ) ) {
 			$this->nominations = new PF_Nominations;
+		}
+	}
+
+	/**
+	 * Sets up the Dashboard admin parts
+	 *
+	 * @since 1.7
+	 */
+	function set_up_form_of() {
+		if ( empty( $this->form_of ) ) {
+			$this->form_of = new PF_Form_Of;
 		}
 	}
 


### PR DESCRIPTION
This resolves #404 

These commits take all feeds not in a folder and stick them on the bottom of the folder list. It will only work in WordPress versions greater than 4.1 and has a check to insure that. It will also create a useful interface for seeing these feeds, with an area with a separate scroll. It also takes both right slide-out bars and sticks them to the menu stylistically, that way it works no matter how far one is scrolled down. 
