### PR TITLE
`continue` -> `return` in pressforward_register_module

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -34,13 +34,13 @@ function pressforward_register_module( $args ) {
 
 	// We need the 'class' and 'slug' terms
 	if ( empty( $r['class'] ) || empty( $r['slug'] ) ) {
-		continue;
+		return;
 	}
 
 	// Ensure the class exists before attempting to initialize it
 	// @todo Should probably have better error reporting
 	if ( ! class_exists( $r['class'] ) ) {
-		continue;
+		return;
 	}
 
 	add_filter( 'pressforward_register_modules', create_function( '$modules', '


### PR DESCRIPTION
The function throws an error with the `continue`s.