### PR TITLE
Add a check to see if wordpress is in wp subdir

### DIFF
--- a/includes/nomthis/nominate-this.php
+++ b/includes/nomthis/nominate-this.php
@@ -22,6 +22,8 @@ if (is_dir($wp_bootstrap.'/wp-admin')){
 	$wp_bootstrap = $wp_bootstrap_d.'/wordpress/wp-admin';
 } elseif (is_dir($wp_bootstrap.'/data/current/wp-admin')) {
 	$wp_bootstrap = $wp_bootstrap.'/data/current/wp-admin';
+} elseif (is_dir($wp_bootstrap.'/wp/wp-admin')) {
+	$wp_bootstrap = $wp_bootstrap.'/wp/wp-admin';
 } else {
 	echo 'Base directory attempt at: <pre>'; var_dump($wp_bootstrap);
   	echo 'Nominate This can not find your WP-Admin directory'; die();


### PR DESCRIPTION
My install has wordpress in the `wp` subdirectory. I don't know if there's a better way of doing this check overall, but for now, at least it fixes it for me :).