### PR TITLE
Fix 'You are not allowed to edit posts in this post type.' error

### DIFF
--- a/includes/feeds.php
+++ b/includes/feeds.php
@@ -85,6 +85,7 @@ class PF_Feeds_Schema {
 			'labels'      => $labels,
 			'description' => __( 'Feeds imported by PressForward&#8217;s Feed Importer', 'pf' ),
 			'public'      => false,
+			'show_ui'      => true,
 			'hierarchical' => true,
 			'supports' 	=> array('title','editor','author','thumbnail','excerpt','custom-fields','page-attributes'),
 			'taxonomies' => array('post_tag'),


### PR DESCRIPTION
Accessing the "Subscribed Feeds" area ( /wp-admin/edit.php?post_type=pf_feed ) generates this error:

> You are not allowed to edit posts in this post type.

This is due to the `'public' => false` setting in the `register_post_type` call in the [feeds.php file, line 87](https://github.com/PressForward/pressforward/blob/master/includes/feeds.php#L87)

From the [codex documentation](https://codex.wordpress.org/Function_Reference/register_post_type) regarding the `public` setting:

> 'false' - Implies exclude_from_search: true, publicly_queryable: false, show_in_nav_menus: false, and show_ui: false. The built-in types nav_menu_item and revision are similar to this. Best used if you'll provide your own editing and viewing interfaces (or none at all)

But we want to allow this in the UI, so we also need to add `'show_ui' => true` - which is what this pull request does.