### PR TITLE
Improvements to relationship table installation

### DIFF
--- a/Core/Schema/Relationships.php
+++ b/Core/Schema/Relationships.php
@@ -37,7 +37,7 @@ class Relationships implements HasActions {
 	 * this file is loaded. Might change this in the future
 	 */
 	public function maybe_install_relationship_table() {
-		if ( ! is_super_admin() ) {
+		if ( ! current_user_can( 'activate_plugins' ) ) {
 			return;
 		}
 

--- a/Core/Schema/Relationships.php
+++ b/Core/Schema/Relationships.php
@@ -41,12 +41,29 @@ class Relationships implements HasActions {
 			return;
 		}
 
-		global $wpdb;
-		$table_exists = $wpdb->get_var( $wpdb->prepare( "SHOW TABLES LIKE %s", $wpdb->prefix . 'pf_relationships' ) );
-
-		if ( ! $table_exists ) {
-			$this->install_relationship_table();
+		if ( $this->schema_is_current() ) {
+			return;
 		}
+
+		$this->install_relationship_table();
+	}
+
+	/**
+	 * Determines whether the installed version of the DB schema is current.
+	 *
+	 * @since 4.2
+	 *
+	 * @return bool
+	 */
+	protected function schema_is_current() {
+		$db_version = get_option( 'pf_relationships_db_version' );
+
+		if ( $db_version && version_compare( $db_version, PF_VERSION, '>=' ) ) {
+			return true;
+		}
+
+		update_option( 'pf_relationships_db_version', PF_VERSION );
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
Hi team - A couple of problems with the installation of the relationships table.

- First, it's not working properly on Multistie, since it does an `is_super_admin()` check. See 9e5dcf8
- Second, the schema check that happens on 'admin_init' is very resource intensive on large databases. I swapped it out for a flag in the options table in f3860c7