### PR TITLE
Delay pressforward_init on plugins_loaded

### DIFF
--- a/Controllers/Modules.php
+++ b/Controllers/Modules.php
@@ -11,7 +11,7 @@ class Modules {
 	var $modules = array();
 
 	public function __construct() {
-		add_action( 'plugins_loaded', array( $this, 'pressforward_init' ) );
+		add_action( 'plugins_loaded', array( $this, 'pressforward_init' ), 20 );
 		add_action( 'pressforward_init', array( $this, 'setup_modules' ), 1000 );
 
 	}


### PR DESCRIPTION
This allows other (Jaxion) plugins to use `plugins_loaded` to bootstrap
themselves and still be able to hook into `pressforward_init` without
it having fired already.