### PR TITLE
update link to new documentation  

### DIFF
--- a/Core/Admin/PFTemplater.php
+++ b/Core/Admin/PFTemplater.php
@@ -282,7 +282,7 @@ class PFTemplater {
 				  </ul>
 				</div>
 				<div class="btn-group" role="group">
-					<a href="https://github.com/PressForward/pressforward/wiki" target="_blank" id="pf-help" class="btn btn-small"><?php _e( 'Need help?', 'pf' ); ?></a>
+					<a href="https://pressforwardadmin.gitbooks.io/pressforward-documentation/content/" target="_blank" id="pf-help" class="btn btn-small"><?php _e( 'Need help?', 'pf' ); ?></a>
 				</div>
 			</div>
 


### PR DESCRIPTION
This updates the "need help" button so that it now links to our new documentation repository on gitbook. (https://pressforwardadmin.gitbooks.io/pressforward-documentation/content/) Closes #966 