### PR TITLE
Initialize WP API client with correct root URL.

### DIFF
--- a/assets/js/pf-api.js
+++ b/assets/js/pf-api.js
@@ -1,8 +1,10 @@
 wp.api.loadPromise.done(function () {
 	//https://github.com/WP-API/client-js/blob/master/js/load.js
+	var wpApiSettings = window.wpApiSettings || {};
+
 	wp.api.init({
 		'versionString': 'pf/v1',
-		'apiRoot': wp.api.utils.getRootUrl() + 'wp-json/'
+		'apiRoot': wpApiSettings.root || wp.api.utils.getRootUrl() + 'wp-json/'
 	});
 
 	jQuery(document.body).ready(function () {


### PR DESCRIPTION
`wp.api.getRootUrl()` returns the host name, which is not the correct
URL root when WP is running in a subdirectory (example.com/foo). The API
client itself uses `wpApiSettings.root` as its fallback, so I've
duplicated that logic here.