### PR TITLE
Avoid unnecessary source link save

### DIFF
--- a/Core/Schema/Feed_Items.php
+++ b/Core/Schema/Feed_Items.php
@@ -380,10 +380,10 @@ class Feed_Items implements HasActions, HasFilters {
 		$url = pressforward( 'controller.metas' )->get_post_pf_meta( $post_id, 'pf_source_link' );
 		if ( empty( $url ) ) {
 			$url = pressforward( 'controller.metas' )->get_post_pf_meta( $post_id, 'item_link' );
+			$source_url = pressforward( 'controller.http_tools' )->resolve_a_url( $url );
+			pressforward( 'controller.metas' )->update_pf_meta( $post_id, 'pf_source_link', $source_url );
 			// pf_log($url);
 		}
-		$source_url = pressforward( 'controller.http_tools' )->resolve_a_url( $url );
-		pressforward( 'controller.metas' )->update_pf_meta( $post_id, 'pf_source_link', $source_url );
 		return $source_url;
 	}
 

--- a/Core/Schema/Feed_Items.php
+++ b/Core/Schema/Feed_Items.php
@@ -377,8 +377,8 @@ class Feed_Items implements HasActions, HasFilters {
 	 * @since 3.4.5
 	 */
 	public function get_source_link( $post_id ) {
-		$url = pressforward( 'controller.metas' )->get_post_pf_meta( $post_id, 'pf_source_link' );
-		if ( empty( $url ) ) {
+		$source_url = pressforward( 'controller.metas' )->get_post_pf_meta( $post_id, 'pf_source_link' );
+		if ( empty( $source_url ) ) {
 			$url = pressforward( 'controller.metas' )->get_post_pf_meta( $post_id, 'item_link' );
 			$source_url = pressforward( 'controller.http_tools' )->resolve_a_url( $url );
 			pressforward( 'controller.metas' )->update_pf_meta( $post_id, 'pf_source_link', $source_url );


### PR DESCRIPTION
I was experiencing some pretty severe performance problems while viewing the main All Content screen. After viewing the query log (using the Query Monitor plugin) I saw that PF was doing two odd things for each item, on every page load:

1. it was running `resolve_a_url()` on the source link
2. it was re-saving the source_link metadata

It did this even when the value already existed in the database, which causes considerable slowdown. 

I've tried to mitigate this by only running the `resolve_a_url()` and save routine when no stored value was found. This dramatically speeds up pageload times.