### PR TITLE
Use wp comment query

### DIFF
--- a/modules/comments/comments.php
+++ b/modules/comments/comments.php
@@ -64,6 +64,7 @@ class PF_Comments extends PF_Module {
 				'count' => true,
 				'post_id' => $id,
 				'type' => self::comment_type,
+				'status' => 'any',
 			)
 		);
 		if ( ! $comment_count ) {

--- a/modules/comments/comments.php
+++ b/modules/comments/comments.php
@@ -58,7 +58,14 @@ class PF_Comments extends PF_Module {
 
 	function get_editorial_comment_count( $id ) {
 		global $wpdb;
-		$comment_count = $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM $wpdb->comments WHERE comment_post_ID = %d AND comment_type = %s", $id, self::comment_type ) );
+		$query = new \WP_Comment_Query();
+		$comment_count = $query->query(
+			array(
+				'count' => true,
+				'post_id' => $id,
+				'type' => self::comment_type,
+			)
+		);
 		if ( ! $comment_count ) {
 			$comment_count = 0; }
 		return $comment_count;


### PR DESCRIPTION
More performance debugging. I found that the All Content page was causing a number of duplicate queries when counting comments. This can be eliminated by adding some sort of caching to the comment-count query. Since `WP_Comment_Query` has this caching built in, I decided to rewrite to use WP's core tool instead of a direct SQL query. (This eliminates the SQL query altogether when running Memcached etc, but at least eliminates the dupes on other environments.)