### PR TITLE
Tell WP to pre-fetch folder posts.

### DIFF
--- a/Core/Schema/Folders.php
+++ b/Core/Schema/Folders.php
@@ -219,10 +219,10 @@ class Folders implements HasActions, HasFilters {
 		$q      = new \WP_Query(
 			array(
 				'post_type' => $this->post_type,
-				'fields'    => 'ids',
 				'orderby'   => 'title',
 				'order'     => 'ASC',
 				'nopaging'  => true,
+				'update_post_meta_cache' => false,
 				'tax_query' => array(
 					array(
 						'taxonomy' => $this->tag_taxonomy,
@@ -231,9 +231,9 @@ class Folders implements HasActions, HasFilters {
 				),
 			)
 		);
-		   $ids = $q->posts;
-		   return $ids;
 
+		$ids = wp_list_pluck( $q->posts, 'ID' );
+		return $ids;
 	}
 
 	public function link_to_see_all_feeds_and_folders() {


### PR DESCRIPTION
Another performance goodie...

The folder-fetching query uses `fields=ids`. This causes post objects (and their associated metadata and taxonomy terms) not to be pre-fetched by `WP_Query`. As such, when PF queries data related to these items later on, it has to fetch the entire objects from the database one at a time. If you have a lot of folders, this can mean dozens more database queries.

I removed `fields=ids` so that `WP_Query` will do the necessary priming of the post and post-term cache. Since it appears that PF doesn't reference postmeta in this context, I added `update_post_meta_cache=false` to eliminate the unneeded query.