### PR TITLE
Basic caching for relationship queries.

### DIFF
--- a/tests/test-cases.php
+++ b/tests/test-cases.php
@@ -59,5 +59,47 @@ class PF_Tests extends PF_UnitTestCase {
 
 		$this->assertSame( false, $value );
 	}
-}
 
+	public function test_pf_get_relationship_value_should_be_cached() {
+		global $wpdb;
+
+		$user_id = $this->factory->user->create();
+		$item_id = $this->factory->post->create();
+		$type = 'star';
+		$relationship_id = $this->factory->relationship->create( array(
+			'user_id' => $user_id,
+			'item_id' => $item_id,
+			'type'    => $type,
+			'value'   => 'foo',
+		) );
+
+		$value = pf_get_relationship_value( $type, $item_id, $user_id );
+		$this->assertSame( 'foo', $value );
+
+		$num_queries = $wpdb->num_queries;
+
+		$value = pf_get_relationship_value( $type, $item_id, $user_id );
+		$this->assertSame( 'foo', $value );
+		$this->assertSame( $num_queries, $wpdb->num_queries );
+	}
+
+	public function test_pf_get_relationship_value_cache_invalidation() {
+		$user_id = $this->factory->user->create();
+		$item_id = $this->factory->post->create();
+		$type = 'star';
+		$relationship_id = $this->factory->relationship->create( array(
+			'user_id' => $user_id,
+			'item_id' => $item_id,
+			'type'    => $type,
+			'value'   => 'foo',
+		) );
+
+		$value = pf_get_relationship_value( $type, $item_id, $user_id );
+		$this->assertSame( 'foo', $value );
+
+		$t = pf_set_relationship( $type, $item_id, $user_id, 'bar' );
+
+		$value = pf_get_relationship_value( $type, $item_id, $user_id );
+		$this->assertSame( 'bar', $value );
+	}
+}


### PR DESCRIPTION
The All Content view, by default, requires user-item relationships to be queried more than once for each item on the page. This results in lots of duplicate queries - at least one dupe for each feed item.

I think that a lot of work could be done to improve performance in this area, but some of these changes would require more extensive rewrites than I had the time for. So I threw some simple caching around the most commonly-used part of the query infrastructure, with some fairly broad cache-busting logic (the `last_changed` incrementor). 

This greatly reduces database I/O due to duplicate queries.

For the time being, single-item queries (`'id'`) are not cached. Doing
this properly - without redundancy - requires a more complex mechanism,
and since PF doesn't appear to actually query for relationship items by
`id` anywhere, it's probably not worth the effort at the moment.

A future project is to pre-fetch relationship data for all items on a page with a single query or two. This isn't really possible right now due to the way the query classes are written, but it's something I might flag for future work.