### PR TITLE
Fix fatal errors in PHP 7.1+

### DIFF
--- a/Controllers/PFtoWPUsers.php
+++ b/Controllers/PFtoWPUsers.php
@@ -195,7 +195,7 @@ class PFtoWPUsers implements SystemUsers {
 	public function get_user_meta($user_id, $meta_key, $single = true){
 		return get_user_meta($user_id, $meta_key, $single);
 	}
-	public function update_user_meta( $user_id, $meta_key, $meta_value, $prev_value ){
+	public function update_user_meta( $user_id, $meta_key, $meta_value, $prev_value = '' ){
 		return update_user_meta( $user_id, $meta_key, $meta_value, $prev_value );
 	}
 


### PR DESCRIPTION
`PFtoWPUsers::update_user_meta()` expects four parameters, but in several places in PF where the method is called, it only passes the first three. This causes a fatal error in PHP 7.1+. See https://secure.php.net/manual/en/migration71.incompatible.php#migration71.incompatible.too-few-arguments-exception

There are a number of ways this might be fixed, but for consistency with WP's `update_user_meta()`, and backward compatibility with third-party tools that might be calling this PF method, I've given the fourth param a default value in the method signature.