### PR TITLE
postmeta filter should respect `$single` argument.

### DIFF
--- a/Controllers/Metas.php
+++ b/Controllers/Metas.php
@@ -1263,6 +1263,10 @@ class Metas implements HasFilters, HasActions {
 		$value = $this->forward_to_origin_status( $object_id );
 		add_filter( 'get_post_metadata', array( $this, 'usable_forward_to_origin_status' ), 10, 4 );
 
+		if ( ! $single ) {
+			$value = array( $value );
+		}
+
 		return $value;
 	}
 }


### PR DESCRIPTION
Possibly related: #899 

The filter `usable_forward_to_origin_status()` doesn't properly respect the `$single` argument. This causes PHP notices when `get_metadata()` expects an array (`$single = false`), which fills up error logs, and may create unforeseen bugs. Specifically, WP core checks in `update_metadata()` to see whether the old value - fetched by `get_metadata()` - matches what's passed to `update_metadata()`. See https://core.trac.wordpress.org/browser/tags/4.9.8/src/wp-includes/meta.php?marks=197,198#L191. It expects an array when `$single = false`, and the fact that it's not getting one in the case of `pf_forward_to_origin` makes me suspect that WP is not properly detecting the filtered value from PF.

The attached PR should do the trick, but please have a look.