### PR TITLE
5.2.x 1044 email notification for comments

### DIFF
--- a/Controllers/PF_Advancement.php
+++ b/Controllers/PF_Advancement.php
@@ -21,7 +21,7 @@ class PF_Advancement implements Advance_System, HasActions {
 		$actions = array(
 			array(
 				'hook'   => 'pf_transition_to_nomination',
-				'method' => 'inform_of_nomination',
+				'method' => 'inform_of_email_action',
 			),
 		);
 		return $actions;
@@ -42,16 +42,28 @@ class PF_Advancement implements Advance_System, HasActions {
 		return wp_insert_term($tag_name, $taxonomy);
 	}
 
-	public function inform_of_nomination(){
+	public function inform_of_email_action( $title_post = false ){
 		$admin_email = get_option( 'pf_nomination_send_email', array() );
-		if($admin_email) {
+		if( $admin_email ) {
 			$siteurl = get_option( 'siteurl', '' );
 			$blogname = get_option( 'blogname', '' );
-			$admin_emails = explode(",", $admin_email);
-			foreach ($admin_emails as $email){
-				wp_mail(trim($email), "New nomination on '".$blogname."'", "A new nomination has been created! Please check it online on " . $siteurl . "/wp-admin/admin.php?page=pf-review");
+			$admin_emails = explode( ",", $admin_email );
+			foreach ( $admin_emails as $email ){
+				if( $title_post ) {
+					$this->send_mail_comment( $email, $blogname, $siteurl, $title_post );
+				} else {
+					$this->send_mail_nomination( $email, $blogname, $siteurl );
+				}
 			}
 		}
+	}
+
+	public function send_mail_nomination( $email, $blogname, $siteurl ){
+		wp_mail(trim($email), "New nomination on '".$blogname."'", "A new nomination has been created! Please check it online on " . $siteurl . "/wp-admin/admin.php?page=pf-review");
+	}
+
+	public function send_mail_comment( $email, $blogname, $siteurl, $title_post ){
+		wp_mail( trim( $email ), 'New comment on \'' . $blogname . '\'', 'A new comment has been posted for the nomination \'' . $title_post . '\'! Please check it online on ' . $siteurl . '/wp-admin/admin.php?page=pf-review' );
 	}
 
 	// Transition Tools

--- a/Core/Admin/Menu.php
+++ b/Core/Admin/Menu.php
@@ -471,6 +471,13 @@ class Menu implements HasActions, HasFilters {
 			} else {
 				update_option( 'pf_nomination_send_email', '' );
 			}
+			if ( isset( $_POST['pf_comment_send_email'] ) ) {
+				$pf_comment_send_email_opt_check = $_POST['pf_comment_send_email'];
+				// print_r($pf_comment_send_email_opt_check); die();
+				update_option( 'pf_comment_send_email', $pf_comment_send_email_opt_check );
+			} else {
+				update_option( 'pf_comment_send_email', '' );
+			}
 			if ( isset( $_POST['pf_present_author_as_primary'] ) ) {
 				$pf_author_opt_check = $_POST['pf_present_author_as_primary'];
 				// print_r($pf_links_opt_check); die();

--- a/Core/Utility/Forward_Tools.php
+++ b/Core/Utility/Forward_Tools.php
@@ -189,6 +189,10 @@ class Forward_Tools {
 		}
 	}
 
+	public function send_email_for_new_comment( $title_post ) {
+		$this->advance_interface->inform_of_email_action( $title_post );
+	}
+
 	public function transition_to_nomination( $item_post_id, $from_meta_added_item = false ) {
 		// Create
 		$post          = $this->item_interface->get_post( $item_post_id, ARRAY_A );

--- a/Interfaces/Advance_System.php
+++ b/Interfaces/Advance_System.php
@@ -10,4 +10,5 @@ interface Advance_System {
 	public function to_last_step( $post = array() );
 	public function to_nomination( $post = array() );
 	public function get_pf_type_by_id( $item_id, $post_type );
+	public function inform_of_email_action( $title_post = false );
 }

--- a/modules/comments/comments.php
+++ b/modules/comments/comments.php
@@ -337,7 +337,13 @@ class PF_Comments extends PF_Module {
 
 			// Register actions -- will be used to set up notifications and other modules can hook into this
 			if ( $comment_id ) {
-				do_action( 'ef_post_insert_editorial_comment', $comment ); }
+				do_action( 'ef_post_insert_editorial_comment', $comment );
+
+				if ( get_option( 'pf_comment_send_email', false ) ) {
+					$title_post = addslashes( get_post( $post_id )->post_title );
+					pressforward( 'utility.forward_tools' )->send_email_for_new_comment( $title_post );
+				}
+			}
 
 			// Prepare response
 			$response = new WP_Ajax_Response();

--- a/parts/settings/tab-site.tpl.php
+++ b/parts/settings/tab-site.tpl.php
@@ -79,6 +79,17 @@
 <p>
 	<?php _e( 'To receive an email notification when there is a new nomination, enter a comma separated list of email notification recipients. If left blank, no notifications will be sent.', 'pf' ); ?>
 </p>
+<p>
+	<?php
+	$pf_comment_send_email = get_user_option( 'pf_comment_send_email', false );
+	if ( 'true' == $pf_comment_send_email ) {
+	$checked = 'checked';
+	} else {
+	$checked = '';
+	}echo '<input id="pf_comment_send_email" type="checkbox" name="pf_comment_send_email" value="true" ' . $checked . ' class="user_setting" />';
+	echo '<label for="pf_comment_send_email" >' . __( 'Also send notifications for each new comments', 'pf' ) . '</label>';
+	?>
+</p>
 <hr />
 <p>
 	<?php

--- a/parts/settings/tab-site.tpl.php
+++ b/parts/settings/tab-site.tpl.php
@@ -83,10 +83,11 @@
 	<?php
 	$pf_comment_send_email = get_user_option( 'pf_comment_send_email', false );
 	if ( 'true' == $pf_comment_send_email ) {
-	$checked = 'checked';
+		$checked = 'checked';
 	} else {
-	$checked = '';
-	}echo '<input id="pf_comment_send_email" type="checkbox" name="pf_comment_send_email" value="true" ' . $checked . ' class="user_setting" />';
+		$checked = '';
+	}
+	echo '<input id="pf_comment_send_email" type="checkbox" name="pf_comment_send_email" value="true" ' . $checked . ' class="user_setting" />';
 	echo '<label for="pf_comment_send_email" >' . __( 'Also send notifications for each new comments', 'pf' ) . '</label>';
 	?>
 </p>


### PR DESCRIPTION
Each new comments should send an email. Only if the admin sets it in the options of WordPress