### PR TITLE
Fix "functions inspecting arguments" PHP compatibility notices.

### DIFF
--- a/Controllers/PF_Loops.php
+++ b/Controllers/PF_Loops.php
@@ -51,7 +51,7 @@ class PF_Loops {
 				$args['relationship'] = $func_args[4];
 			}
 		} else {
-			$args = func_get_arg( 0 );
+			$args = $func_args[0];
 		}
 
 		// Make sure default values are set.

--- a/Libraries/FiveFiltersReadability/JSLikeHTMLElement.php
+++ b/Libraries/FiveFiltersReadability/JSLikeHTMLElement.php
@@ -78,6 +78,7 @@ class JSLikeHTMLElement extends DOMElement {
 				}
 			}
 		} else {
+			// phpcs:ignore PHPCompatibility.FunctionUse.ArgumentFunctionsReportCurrentValue.Changed -- Inspected & found ok.
 			$trace = debug_backtrace();
 			trigger_error( 'Undefined property via __set(): ' . $name . ' in ' . $trace[0]['file'] . ' on line ' . $trace[0]['line'], E_USER_NOTICE );
 		}
@@ -99,6 +100,7 @@ class JSLikeHTMLElement extends DOMElement {
 			return $inner;
 		}
 
+		// phpcs:ignore PHPCompatibility.FunctionUse.ArgumentFunctionsReportCurrentValue.NeedsInspection -- Inspected & found ok.
 		$trace = debug_backtrace();
 		trigger_error( 'Undefined property via __get(): ' . $name . ' in ' . $trace[0]['file'] . ' on line ' . $trace[0]['line'], E_USER_NOTICE );
 		return null;

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1514,6 +1514,8 @@ function assure_log_string( $message ) {
 function pf_log( $message = '', $display = false, $reset = false, $return = false ) {
 	static $debug;
 
+	$trace = debug_backtrace();
+
 	if ( $return && ( 0 === $debug ) ) {
 		return assure_log_string( $message );
 	}
@@ -1562,7 +1564,6 @@ function pf_log( $message = '', $display = false, $reset = false, $return = fals
 
 	$message = assure_log_string( $message );
 
-	$trace = debug_backtrace();
 	foreach ( $trace as $key => $call ) {
 
 		if ( in_array( $call['function'], array( 'call_user_func_array', 'do_action', 'apply_filter', 'call_user_func', 'do_action_ref_array', 'require_once' ) ) ) {


### PR DESCRIPTION
Functions like `debug_backtrace()` and `func_get_args()` must be run before
any other code is run that modifies the values of the function parameters,
since PHP 7.0. See eg https://www.php.net/manual/en/function.func-get-arg.php#refsect1-function.func-get-arg-notes.

In the case of the FiveFiltersReadability library, I could see that there was
no way for the values to be modified, so I added a `phpcs:ignore` comment
instead of making a code change.