### PR TITLE
Fix various notices

### DIFF
--- a/Controllers/PF_Readability.php
+++ b/Controllers/PF_Readability.php
@@ -28,8 +28,9 @@ class PF_Readability {
 			$url = pressforward( 'controller.http_tools' )->resolve_full_url( $url );
 			// var_dump($url); die();
 			$descrip = rawurldecode( $descrip );
-		if ( get_magic_quotes_gpc() ) {
-			$descrip = stripslashes( $descrip ); }
+		if ( false !== strpos( $descrip, '\\' ) ) {
+			$descrip = stripslashes( $descrip );
+		}
 
 		if ( $authorship == 'aggregation' ) {
 			$aggregated = true;

--- a/Libraries/PFSimpleHtmlDom.php
+++ b/Libraries/PFSimpleHtmlDom.php
@@ -1073,7 +1073,7 @@ class pf_simple_html_dom {
 			return true;
 		}
 
-		if ( ! preg_match( '/^[\w-:]+$/', $tag ) ) {
+		if ( ! preg_match( '/^[\w\-:]+$/', $tag ) ) {
 			$node->_[ PF_HDOM_INFO_TEXT ] = '<' . $tag . $this->copy_until( '<>' );
 			if ( $this->char === '<' ) {
 				$this->link_nodes( $node, false );

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -422,6 +422,9 @@ function pf_prep_item_for_submit( $item ) {
 		}
 
 		if ( is_array( $itemPart ) ) {
+			if ( 'nominators' === $itemKey ) {
+				$itemPart = array_keys( $itemPart );
+			}
 			$itemPart = implode( ',',$itemPart );
 		}
 


### PR DESCRIPTION
Hi,

This PR fixes various notices for PHP 7.3+:

- Deprecated `get_magic_quotes_gpc()` notice -- deprecated as of PHP 7.4. I've replaced this with a `strpos()` slash check.
- "preg_match(): Compilation failed: invalid range in character classes at offset 4" warning -- notice shows up in PHP 7.3+. Fix is to escape the hyphen in the `preg_match()` call.
- "Array to string conversion" notice -- not related to PHP 7.3, but came across this while checking the "PressForward > Nominated" page. View the commit message for more info.

Let me know if you have any questions.