### PR TITLE
Feature/1094 cache external fetch

### DIFF
--- a/Controllers/HTTPTools.php
+++ b/Controllers/HTTPTools.php
@@ -144,27 +144,36 @@ class HTTPTools implements HasActions {
 			$args[0] = $url;
 			unset( $args[1] );
 			// var_dump($args);
-			$r = call_user_func_array( $function, $args );
-			// var_dump($r); die();
-			// "A variable is considered empty if it does not exist or if its value equals FALSE"
-			if ( is_wp_error( $r ) || empty( $r ) ) {
-				$non_ssl_url = set_url_scheme( $url, 'http' );
-				if ( $non_ssl_url != $url ) {
-							$args[0] = $non_ssl_url;
-					$r               = call_user_func_array( $function, $args );
-							// var_dump($url); die();
-				}
-					// $r = false;
-				if ( ! $r || is_wp_error( $r ) ) {
-					// Last Chance!
-					if ( 'file_get_contents' != $function ) {
-						$response = file_get_contents( $url_first );
-						// var_dump($r); die();
-					} else {
-						// bail
-						$response = false;
+
+			$cache_key = $function . '_' . $url;
+			$cached    = wp_cache_get( $cache_key, 'pressforward_external_pages' );
+			if ( false === $cached ) {
+				$args[1] = [ 'timeout' => 30 ];
+				$r = call_user_func_array( $function, $args );
+				// var_dump($r); die();
+				// "A variable is considered empty if it does not exist or if its value equals FALSE"
+				if ( is_wp_error( $r ) || empty( $r ) ) {
+					$non_ssl_url = set_url_scheme( $url, 'http' );
+					if ( $non_ssl_url != $url ) {
+								$args[0] = $non_ssl_url;
+						$r               = call_user_func_array( $function, $args );
+								// var_dump($url); die();
+					}
+						// $r = false;
+					if ( ! $r || is_wp_error( $r ) ) {
+						// Last Chance!
+						if ( 'file_get_contents' != $function ) {
+							$response = file_get_contents( $url_first );
+							// var_dump($r); die();
+						} else {
+							// bail
+							$response = false;
+						}
 					}
 				}
+				wp_cache_set( $cache_key, $r, 'pressforward_external_pages' );
+			} else {
+				$r = $cached;
 			}
 		}
 		$response          = $r;

--- a/Libraries/PFOpenGraph.php
+++ b/Libraries/PFOpenGraph.php
@@ -55,7 +55,7 @@ class PFOpenGraph implements Iterator {
 		if ( false !== $cached ) {
 			$response_body = $cached;
 		} else {
-			$response = pf_de_https( $URI, 'wp_remote_get', array( 'timeout' => '5' ) );
+			$response = pf_de_https( $URI, 'wp_remote_get', array( 'timeout' => '30' ) );
 			if ( $response && ! is_wp_error( $response ) ) {
 				$response_body = wp_remote_retrieve_body( $response );
 			}

--- a/Libraries/PFOpenGraph.php
+++ b/Libraries/PFOpenGraph.php
@@ -49,7 +49,8 @@ class PFOpenGraph implements Iterator {
 	 * @return OpenGraph
 	 */
 	public static function fetch( $URI ) {
-		$cached = wp_cache_get( $URI, 'pressforward_external_pages' );
+		$cache_key = 'wp_remote_get_' . $URI;
+		$cached = wp_cache_get( $cache_key, 'pressforward_external_pages' );
 		$response_body = null;
 		if ( false !== $cached ) {
 			$response_body = $cached;
@@ -57,8 +58,8 @@ class PFOpenGraph implements Iterator {
 			$response = pf_de_https( $URI, 'wp_remote_get', array( 'timeout' => '5' ) );
 			if ( $response && ! is_wp_error( $response ) ) {
 				$response_body = wp_remote_retrieve_body( $response );
-				wp_cache_set( $URI, $response_body, 'pressforward_external_pages' );
 			}
+			wp_cache_set( $cache_key, $response_body, 'pressforward_external_pages' );
 		}
 
 		if ( ! $response_body ) {


### PR DESCRIPTION
I chose to piggyback on the `pressforward_external_pages` cache mechanism introduced in 137d7df1919fdc7af4ebd7503d74b05e95a57fe8; see #1037. 

Because the change involved reaching into the `get_url_content()` method, I needed to account for the possibility that someone would use something other than `wp_remote_get()`. As such, I assemble cache keys by concatenating the URL and the fetch function.

I also made a change so that fetch errors are cached, to avoid cases where timeouts were piling up on each other.